### PR TITLE
fix link to "contact us" form

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -38,7 +38,7 @@
       = succeed "," do
         = link_to "our Github repository", "https://github.com/coralineada/opensourceforwomen.org/"
       or use our
-      = link_to "contact form", "/"
+      = link_to "contact form", contact_us_path
       to send us an email. We also welcome contributions in the form of pull requests.
 
     %p


### PR DESCRIPTION
I noticed that this link was broken.